### PR TITLE
Переделал на испорт numpy напрямую, без comtypes

### DIFF
--- a/_unit_tests/image/test_create.py
+++ b/_unit_tests/image/test_create.py
@@ -1,7 +1,6 @@
 import unittest
-from os.path import exists
 
-from comtypes.safearray import numpy
+import numpy
 
 from image import Image, write
 


### PR DESCRIPTION
comtypes Содержит код для работы с COM, который отсутствует в Linux, поэтому пакет даже не грузится. В тесте использовался только один numpy.array, который импортировался через comtypes. Преимуществ такого непрямого импорта не увидел. Предлагаю импортировать напрямую.