### PR TITLE
Переделка тестов Image

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from tempfile import TemporaryDirectory
 
 
 class TestFileHelper(object):
@@ -20,6 +21,9 @@ class TestFileHelper(object):
 
     # резервируем имя в классе, во избежание AttributeError при первом обращении
     _test_class_path = None
+
+    _temp_prefix = None
+    _temp_suffix = None
 
     @staticmethod
     def _data_subdir() -> str:
@@ -69,3 +73,8 @@ class TestFileHelper(object):
         data_subdir = self._data_subdir()
         full_path = os.path.join(class_path, data_subdir, *names)
         return os.path.normpath(full_path)
+
+    def _temp_dir(self):
+        return TemporaryDirectory(prefix=self._temp_prefix, suffix=self._temp_suffix)
+        # with self._temp_dir() as tempdir:
+        #     write_path = os.path.join(tempdir, 'test_write_image.jpg')

--- a/tests/image/test_create.py
+++ b/tests/image/test_create.py
@@ -4,12 +4,11 @@ from os.path import join
 
 from numpy import array
 
+from helpers import TestFileHelper
 from image import Image, write
 
 
-class ImageCreate(unittest.TestCase):
-
-    path = './test_data/'
+class ImageCreate(unittest.TestCase, TestFileHelper):
     w = 100
     h = 100
     c = 3
@@ -17,40 +16,45 @@ class ImageCreate(unittest.TestCase):
     def test_create_black_image(self):
         reference_color = array([0, 0, 0])
         img = Image.create(size=(self.w, self.h))
-        write(join(self.path, 'text_image_create_black.png'), img)
-        test_color = img[int(self.h/2)][int(self.w/2)]
+        with self._temp_dir() as temp_dir:
+            write(join(temp_dir, 'text_image_create_black.png'), img)
+        test_color = img[int(self.h / 2)][int(self.w / 2)]
         check = test_color == reference_color[::-1]
         self.assertTrue(check.all())
 
     def test_create_white_image(self):
         reference_color = array([255, 255, 255])
         img = Image.create(size=(self.w, self.h), background=reference_color)
-        write(join(self.path, 'text_image_create_white.png'), img)
-        test_color = img[int(self.h/2)][int(self.w/2)]
+        with self._temp_dir() as temp_dir:
+            write(join(temp_dir, 'text_image_create_white.png'), img)
+        test_color = img[int(self.h / 2)][int(self.w / 2)]
         check = test_color == reference_color[::-1]
         self.assertTrue(check.all())
 
     def test_create_red_image(self):
         reference_color = array([255, 0, 0])
         img = Image.create(size=(self.w, self.h), background=reference_color)
-        write(join(self.path, 'text_image_create_red.png'), img)
-        test_color = img[int(self.h/2)][int(self.w/2)]
+        with self._temp_dir() as temp_dir:
+            write(join(temp_dir, 'text_image_create_red.png'), img)
+        test_color = img[int(self.h / 2)][int(self.w / 2)]
         check = test_color == reference_color[::-1]
         self.assertTrue(check.all())
 
     def test_create_green_image(self):
         reference_color = array([0, 255, 0])
         img = Image.create(size=(self.w, self.h), background=reference_color)
-        write(join(self.path, 'text_image_create_green.png'), img)
-        test_color = img[int(self.h/2)][int(self.w/2)]
+        with self._temp_dir() as temp_dir:
+            write(join(temp_dir, 'text_image_create_green.png'), img)
+        test_color = img[int(self.h / 2)][int(self.w / 2)]
         check = test_color == reference_color[::-1]
         self.assertTrue(check.all())
 
     def test_create_blue_image(self):
         reference_color = array([0, 0, 255])
         img = Image.create(size=(self.w, self.h), background=reference_color)
-        write(join(self.path, 'text_image_create_blue.png'), img)
-        test_color = img[int(self.h/2)][int(self.w/2)]
+        with self._temp_dir() as temp_dir:
+            write(join(temp_dir, 'text_image_create_blue.png'), img)
+        test_color = img[int(self.h / 2)][int(self.w / 2)]
         check = test_color == reference_color[::-1]
         self.assertTrue(check.all())
 

--- a/tests/image/test_create.py
+++ b/tests/image/test_create.py
@@ -1,62 +1,55 @@
-
 import unittest
-from os.path import join
 
-from numpy import array
+import numpy
 
 from helpers import TestFileHelper
-from image import Image, write
+from image import Image
 
 
 class ImageCreate(unittest.TestCase, TestFileHelper):
-    w = 100
-    h = 100
-    c = 3
+    SIZE = (100, 100)
 
-    def test_create_black_image(self):
-        reference_color = array([0, 0, 0])
-        img = Image.create(size=(self.w, self.h))
-        with self._temp_dir() as temp_dir:
-            write(join(temp_dir, 'text_image_create_black.png'), img)
-        test_color = img[int(self.h / 2)][int(self.w / 2)]
-        check = test_color == reference_color[::-1]
-        self.assertTrue(check.all())
+    BLACK = (0, 0, 0)
+    WHITE = (255, 255, 255)
+    RED = (255, 0, 0)
+    GREEN = (0, 255, 0)
+    BLUE = (0, 0, 255)
 
-    def test_create_white_image(self):
-        reference_color = array([255, 255, 255])
-        img = Image.create(size=(self.w, self.h), background=reference_color)
-        with self._temp_dir() as temp_dir:
-            write(join(temp_dir, 'text_image_create_white.png'), img)
-        test_color = img[int(self.h / 2)][int(self.w / 2)]
-        check = test_color == reference_color[::-1]
-        self.assertTrue(check.all())
+    def test_default_background(self):
+        created_image = Image.create(size=self.SIZE, background=None)
+        self.assertIsNotNone(created_image)
+        expected_image = numpy.full((self.SIZE[1], self.SIZE[0], len(self.BLACK)), self.BLACK[::-1])
+        numpy.testing.assert_array_equal(created_image, expected_image)
 
-    def test_create_red_image(self):
-        reference_color = array([255, 0, 0])
-        img = Image.create(size=(self.w, self.h), background=reference_color)
-        with self._temp_dir() as temp_dir:
-            write(join(temp_dir, 'text_image_create_red.png'), img)
-        test_color = img[int(self.h / 2)][int(self.w / 2)]
-        check = test_color == reference_color[::-1]
-        self.assertTrue(check.all())
+    def test_black(self):
+        created_image = Image.create(size=self.SIZE, background=self.BLACK)
+        self.assertIsNotNone(created_image)
+        expected_image = numpy.full((self.SIZE[1], self.SIZE[0], len(self.BLACK)), self.BLACK[::-1])
+        numpy.testing.assert_array_equal(created_image, expected_image)
 
-    def test_create_green_image(self):
-        reference_color = array([0, 255, 0])
-        img = Image.create(size=(self.w, self.h), background=reference_color)
-        with self._temp_dir() as temp_dir:
-            write(join(temp_dir, 'text_image_create_green.png'), img)
-        test_color = img[int(self.h / 2)][int(self.w / 2)]
-        check = test_color == reference_color[::-1]
-        self.assertTrue(check.all())
+    def test_white(self):
+        created_image = Image.create(size=self.SIZE, background=self.WHITE)
+        self.assertIsNotNone(created_image)
+        expected_image = numpy.full((self.SIZE[1], self.SIZE[0], len(self.WHITE)), self.WHITE[::-1])
+        numpy.testing.assert_array_equal(created_image, expected_image)
 
-    def test_create_blue_image(self):
-        reference_color = array([0, 0, 255])
-        img = Image.create(size=(self.w, self.h), background=reference_color)
-        with self._temp_dir() as temp_dir:
-            write(join(temp_dir, 'text_image_create_blue.png'), img)
-        test_color = img[int(self.h / 2)][int(self.w / 2)]
-        check = test_color == reference_color[::-1]
-        self.assertTrue(check.all())
+    def test_red(self):
+        created_image = Image.create(size=self.SIZE, background=self.RED)
+        self.assertIsNotNone(created_image)
+        expected_image = numpy.full((self.SIZE[1], self.SIZE[0], len(self.RED)), self.RED[::-1])
+        numpy.testing.assert_array_equal(created_image, expected_image)
+
+    def test_green(self):
+        created_image = Image.create(size=self.SIZE, background=self.GREEN)
+        self.assertIsNotNone(created_image)
+        expected_image = numpy.full((self.SIZE[1], self.SIZE[0], len(self.GREEN)), self.GREEN[::-1])
+        numpy.testing.assert_array_equal(created_image, expected_image)
+
+    def test_blue(self):
+        created_image = Image.create(size=self.SIZE, background=self.BLUE)
+        self.assertIsNotNone(created_image)
+        expected_image = numpy.full((self.SIZE[1], self.SIZE[0], len(self.BLUE)), self.BLUE[::-1])
+        numpy.testing.assert_array_equal(created_image, expected_image)
 
 
 if __name__ == '__main__':

--- a/tests/image/test_draw.py
+++ b/tests/image/test_draw.py
@@ -1,50 +1,59 @@
 import unittest
-from os.path import join
+
+import numpy
 
 from helpers import TestFileHelper
-from image import Image, write
+from image import Image, read
 
 
 class DrawRect(unittest.TestCase, TestFileHelper):
-    w, h = 200, 300
-    top_left = int((w * 1 / 4)), int(h * 1 / 4)
-    bottom_right = int((w * 3 / 4)), int(h * 3 / 4)
+    WIDTH = 200
+    HEIGHT = 300
+    SIZE = (WIDTH, HEIGHT)
+    RECT_POINT1 = (int(WIDTH * 1 / 4), int(HEIGHT * 1 / 4))
+    RECT_POINT2 = (int(WIDTH * 3 / 4), int(HEIGHT * 3 / 4))
+
+    BLACK = (0, 0, 0)
+    WHITE = (255, 255, 255)
+    RED = (255, 0, 0)
+    GREEN = (0, 255, 0)
+    BLUE = (0, 0, 255)
 
     def test_rect_baseline(self):
-        img = Image.create(size=(self.w, self.h))
-        rect = img.draw.rectangle(self.top_left, self.bottom_right, color=(255, 255, 255))
-        with self._temp_dir() as temp_dir:
-            write(join(temp_dir, 'test_draw_rect_base.png'), rect)
+        img = Image.create(size=self.SIZE)
+        rect = img.draw.rectangle(self.RECT_POINT1, self.RECT_POINT2, color=self.WHITE)
+        expected = read(self._test_file('test_draw_rect_base.png'))
+        numpy.testing.assert_array_equal(rect, expected)
 
     def test_rect_blue(self):
-        img = Image.create(size=(self.w, self.h))
-        rect = img.draw.rectangle(self.top_left, self.bottom_right, color=(0, 0, 255))
-        with self._temp_dir() as temp_dir:
-            write(join(temp_dir, 'test_draw_rect_blue.png'), rect)
+        img = Image.create(size=self.SIZE)
+        rect = img.draw.rectangle(self.RECT_POINT1, self.RECT_POINT2, color=self.BLUE)
+        expected = read(self._test_file('test_draw_rect_blue.png'))
+        numpy.testing.assert_array_equal(rect, expected)
 
     def test_rect_red(self):
-        img = Image.create(size=(self.w, self.h))
-        rect = img.draw.rectangle(self.top_left, self.bottom_right, color=(255, 0, 0))
-        with self._temp_dir() as temp_dir:
-            write(join(temp_dir, 'test_draw_rect_red.png'), rect)
+        img = Image.create(size=self.SIZE)
+        rect = img.draw.rectangle(self.RECT_POINT1, self.RECT_POINT2, color=self.RED)
+        expected = read(self._test_file('test_draw_rect_red.png'))
+        numpy.testing.assert_array_equal(rect, expected)
 
     def test_rect_green(self):
-        img = Image.create(size=(self.w, self.h))
-        rect = img.draw.rectangle(self.top_left, self.bottom_right, color=(0, 255, 0))
-        with self._temp_dir() as temp_dir:
-            write(join(temp_dir, 'test_draw_rect_green.png'), rect)
+        img = Image.create(size=self.SIZE)
+        rect = img.draw.rectangle(self.RECT_POINT1, self.RECT_POINT2, color=self.GREEN)
+        expected = read(self._test_file('test_draw_rect_green.png'))
+        numpy.testing.assert_array_equal(rect, expected)
 
     def test_rect_thick(self):
-        img = Image.create(size=(self.w, self.h))
-        rect = img.draw.rectangle(self.top_left, self.bottom_right, color=(255, 255, 255), thickness=5)
-        with self._temp_dir() as temp_dir:
-            write(join(temp_dir, 'test_draw_rect_thick.png'), rect)
+        img = Image.create(size=self.SIZE)
+        rect = img.draw.rectangle(self.RECT_POINT1, self.RECT_POINT2, color=self.WHITE, thickness=5)
+        expected = read(self._test_file('test_draw_rect_thick.png'))
+        numpy.testing.assert_array_equal(rect, expected)
 
     def test_rect_filled(self):
-        img = Image.create(size=(self.w, self.h))
-        rect = img.draw.rectangle(self.top_left, self.bottom_right, color=(255, 255, 255), filled=True)
-        with self._temp_dir() as temp_dir:
-            write(join(temp_dir, 'test_draw_rect_filled.png'), rect)
+        img = Image.create(size=self.SIZE)
+        rect = img.draw.rectangle(self.RECT_POINT1, self.RECT_POINT2, color=self.WHITE, filled=True)
+        expected = read(self._test_file('test_draw_rect_filled.png'))
+        numpy.testing.assert_array_equal(rect, expected)
 
 
 if __name__ == '__main__':

--- a/tests/image/test_draw.py
+++ b/tests/image/test_draw.py
@@ -1,49 +1,50 @@
 import unittest
+from os.path import join
 
+from helpers import TestFileHelper
 from image import Image, write
 
 
-class DrawRect(unittest.TestCase):
-
+class DrawRect(unittest.TestCase, TestFileHelper):
     w, h = 200, 300
-    top_left = int((w * 1/4)), int(h * 1/4)
-    bottom_right = int((w * 3/4)), int(h * 3/4)
+    top_left = int((w * 1 / 4)), int(h * 1 / 4)
+    bottom_right = int((w * 3 / 4)), int(h * 3 / 4)
 
     def test_rect_baseline(self):
-
         img = Image.create(size=(self.w, self.h))
         rect = img.draw.rectangle(self.top_left, self.bottom_right, color=(255, 255, 255))
-        write(r'.\test_data\test_draw_rect_base.png', rect)
+        with self._temp_dir() as temp_dir:
+            write(join(temp_dir, 'test_draw_rect_base.png'), rect)
 
     def test_rect_blue(self):
-
         img = Image.create(size=(self.w, self.h))
         rect = img.draw.rectangle(self.top_left, self.bottom_right, color=(0, 0, 255))
-        write(r'.\test_data\test_draw_rect_blue.png', rect)
+        with self._temp_dir() as temp_dir:
+            write(join(temp_dir, 'test_draw_rect_blue.png'), rect)
 
     def test_rect_red(self):
-
         img = Image.create(size=(self.w, self.h))
         rect = img.draw.rectangle(self.top_left, self.bottom_right, color=(255, 0, 0))
-        write(r'.\test_data\test_draw_rect_red.png', rect)
+        with self._temp_dir() as temp_dir:
+            write(join(temp_dir, 'test_draw_rect_red.png'), rect)
 
     def test_rect_green(self):
-
         img = Image.create(size=(self.w, self.h))
         rect = img.draw.rectangle(self.top_left, self.bottom_right, color=(0, 255, 0))
-        write(r'.\test_data\test_draw_rect_green.png', rect)
+        with self._temp_dir() as temp_dir:
+            write(join(temp_dir, 'test_draw_rect_green.png'), rect)
 
     def test_rect_thick(self):
-
         img = Image.create(size=(self.w, self.h))
         rect = img.draw.rectangle(self.top_left, self.bottom_right, color=(255, 255, 255), thickness=5)
-        write(r'.\test_data\test_draw_rect_thick.png', rect)
+        with self._temp_dir() as temp_dir:
+            write(join(temp_dir, 'test_draw_rect_thick.png'), rect)
 
     def test_rect_filled(self):
-
         img = Image.create(size=(self.w, self.h))
         rect = img.draw.rectangle(self.top_left, self.bottom_right, color=(255, 255, 255), filled=True)
-        write(r'.\test_data\test_draw_rect_filled.png', rect)
+        with self._temp_dir() as temp_dir:
+            write(join(temp_dir, 'test_draw_rect_filled.png'), rect)
 
 
 if __name__ == '__main__':

--- a/tests/image/test_file_write.py
+++ b/tests/image/test_file_write.py
@@ -13,10 +13,9 @@ class WriteImage(unittest.TestCase, TestFileHelper):
 
     def test_absolute_path(self):
         # Test writing a valid image
-        # image = read(self._test_file('test_read_image.jpg'))
-        image = read(self._test_file('test_write_image.jpg'))
+        image = read(self._test_file('test_read_image.jpg'))
         with self._temp_dir() as temp_dir:
-            path = join(temp_dir, 'test_write_image.jpg')
+            path = join(temp_dir, 'test_write_image.png')
             path = abspath(path)
             write(path, image)
             self.assertTrue(exists(path))
@@ -26,10 +25,9 @@ class WriteImage(unittest.TestCase, TestFileHelper):
 
     def test_relative_path(self):
         # Test writing a valid image
-        # image = read(self._test_file('test_read_image.jpg'))
-        image = read(self._test_file('test_write_image.jpg'))
+        image = read(self._test_file('test_read_image.jpg'))
         with self._temp_dir() as temp_dir:
-            path = join(temp_dir, 'test_write_image.jpg')
+            path = join(temp_dir, 'test_write_image.png')
             path = relpath(path, getcwd())
             write(path, image)
             self.assertTrue(exists(path))
@@ -39,10 +37,9 @@ class WriteImage(unittest.TestCase, TestFileHelper):
 
     def test_invalid_path(self):
         # Test writing a valid image
-        # image = read(self._test_file('test_read_image.jpg'))
-        image = read(self._test_file('test_write_image.jpg'))
+        image = read(self._test_file('test_read_image.jpg'))
         with self._temp_dir() as temp_dir:
-            path = join(temp_dir, 'not_exist_dir', 'test_write_image.jpg')
+            path = join(temp_dir, 'not_exist_dir', 'test_write_image.png')
 
             self.assertFalse(exists(dirname(path)))
 
@@ -54,8 +51,7 @@ class WriteImage(unittest.TestCase, TestFileHelper):
 
     def test_invalid_ext(self):
         # Test writing a valid image with improper file extension
-        # image = read(self._test_file('test_read_image.jpg'))
-        image = read(self._test_file('test_write_image.jpg'))
+        image = read(self._test_file('test_read_image.jpg'))
         with self._temp_dir() as temp_dir:
             path = join(temp_dir, 'foo.xxx')
             with self.assertRaises(cv2.error):

--- a/tests/image/test_file_write.py
+++ b/tests/image/test_file_write.py
@@ -1,43 +1,51 @@
 import unittest
-from os.path import exists, dirname
-from shutil import rmtree
+from os import getcwd
+from os.path import exists, dirname, join, abspath, relpath
 
 import cv2
 
+from helpers import TestFileHelper
 from image import read, write
 
 
-class WriteImage(unittest.TestCase):
-
-    img = read(r'.\test_data\test_read_image.jpg')
+class WriteImage(unittest.TestCase, TestFileHelper):
 
     def test_absolute_path(self):
         # Test writing a valid image
-        path = r'C:\test\test_write_image.jpg'
-        write(path, self.img)
-        self.assertTrue(exists(path))
+        image = read(self._test_file('test_read_image.jpg'))
+        with self._temp_dir() as temp_dir:
+            path = join(temp_dir, 'test_write_image.jpg')
+            path = abspath(path)
+            write(path, image)
+            self.assertTrue(exists(path))
 
     def test_relative_path(self):
         # Test writing a valid image
-        path = r'.\test_data\test_write_image.jpg'
-        write(path, self.img)
-        self.assertTrue(exists(path))
+        image = read(self._test_file('test_read_image.jpg'))
+        with self._temp_dir() as temp_dir:
+            path = join(temp_dir, 'test_write_image.jpg')
+            path = relpath(path, getcwd())
+            write(path, image)
+            self.assertTrue(exists(path))
 
     def test_invalid_path(self):
         # Test writing a valid image
-        path = r'C:\test2\test_write_image.jpg'
+        image = read(self._test_file('test_read_image.jpg'))
+        with self._temp_dir() as temp_dir:
+            path = join(temp_dir, 'not_exist_dir', 'test_write_image.jpg')
 
-        if exists(dirname(path)):
-            rmtree(dirname(path))
+            self.assertFalse(exists(dirname(path)))
 
-        write(path, self.img)
-        self.assertTrue(exists(path))
+            write(path, image)
+            self.assertTrue(exists(path))
 
     def test_invalid_ext(self):
         # Test writing a valid image with improper file extension
-        path = r'.\test_data\foo.xxx'
-        with self.assertRaises(cv2.error):
-            write(path, self.img)
+        image = read(self._test_file('test_read_image.jpg'))
+        with self._temp_dir() as temp_dir:
+            path = join(temp_dir, 'foo.xxx')
+            with self.assertRaises(cv2.error):
+                write(path, image)
 
 
 if __name__ == '__main__':

--- a/tests/image/test_file_write.py
+++ b/tests/image/test_file_write.py
@@ -3,6 +3,7 @@ from os import getcwd
 from os.path import exists, dirname, join, abspath, relpath
 
 import cv2
+import numpy
 
 from helpers import TestFileHelper
 from image import read, write
@@ -12,25 +13,34 @@ class WriteImage(unittest.TestCase, TestFileHelper):
 
     def test_absolute_path(self):
         # Test writing a valid image
-        image = read(self._test_file('test_read_image.jpg'))
+        # image = read(self._test_file('test_read_image.jpg'))
+        image = read(self._test_file('test_write_image.jpg'))
         with self._temp_dir() as temp_dir:
             path = join(temp_dir, 'test_write_image.jpg')
             path = abspath(path)
             write(path, image)
             self.assertTrue(exists(path))
 
+            new_image = read(path)
+            numpy.testing.assert_array_equal(new_image, image)
+
     def test_relative_path(self):
         # Test writing a valid image
-        image = read(self._test_file('test_read_image.jpg'))
+        # image = read(self._test_file('test_read_image.jpg'))
+        image = read(self._test_file('test_write_image.jpg'))
         with self._temp_dir() as temp_dir:
             path = join(temp_dir, 'test_write_image.jpg')
             path = relpath(path, getcwd())
             write(path, image)
             self.assertTrue(exists(path))
 
+            new_image = read(path)
+            numpy.testing.assert_array_equal(new_image, image)
+
     def test_invalid_path(self):
         # Test writing a valid image
-        image = read(self._test_file('test_read_image.jpg'))
+        # image = read(self._test_file('test_read_image.jpg'))
+        image = read(self._test_file('test_write_image.jpg'))
         with self._temp_dir() as temp_dir:
             path = join(temp_dir, 'not_exist_dir', 'test_write_image.jpg')
 
@@ -39,9 +49,13 @@ class WriteImage(unittest.TestCase, TestFileHelper):
             write(path, image)
             self.assertTrue(exists(path))
 
+            new_image = read(path)
+            numpy.testing.assert_array_equal(new_image, image)
+
     def test_invalid_ext(self):
         # Test writing a valid image with improper file extension
-        image = read(self._test_file('test_read_image.jpg'))
+        # image = read(self._test_file('test_read_image.jpg'))
+        image = read(self._test_file('test_write_image.jpg'))
         with self._temp_dir() as temp_dir:
             path = join(temp_dir, 'foo.xxx')
             with self.assertRaises(cv2.error):

--- a/tests/image/test_mode.py
+++ b/tests/image/test_mode.py
@@ -1,13 +1,18 @@
 import unittest
+from os.path import join
+
+from helpers import TestFileHelper
 from image import read, write
 
 
-class ModeConversions(unittest.TestCase):
+class ModeConversions(unittest.TestCase, TestFileHelper):
 
     def test_to_greyscale(self):
-        rgb = read(r'./test_data/test_rgb.png')
+        rgb = read(self._test_file('test_rgb.png'))
         grey = rgb.mode.to_greyscale()
-        write(r'./test_data/test_greyscale.png', grey)
+        with self._temp_dir() as temp_dir:
+            path = join(temp_dir, 'test_greyscale.png')
+            write(path, grey)
         self.assertEqual(rgb.channels, 3)
         self.assertEqual(grey.channels, 0)
 

--- a/tests/image/test_mode.py
+++ b/tests/image/test_mode.py
@@ -1,8 +1,9 @@
 import unittest
-from os.path import join
+
+import numpy
 
 from helpers import TestFileHelper
-from image import read, write
+from image import read
 
 
 class ModeConversions(unittest.TestCase, TestFileHelper):
@@ -10,11 +11,12 @@ class ModeConversions(unittest.TestCase, TestFileHelper):
     def test_to_greyscale(self):
         rgb = read(self._test_file('test_rgb.png'))
         grey = rgb.mode.to_greyscale()
-        with self._temp_dir() as temp_dir:
-            path = join(temp_dir, 'test_greyscale.png')
-            write(path, grey)
         self.assertEqual(rgb.channels, 3)
         self.assertEqual(grey.channels, 0)
+        # ожидаемая картинка размером 100*100 и с одним планом
+        # левая половина заполнена 91, а правая 123
+        expected = numpy.full((100, 100), [91] * 50 + [123] * 50)
+        numpy.testing.assert_array_equal(grey, expected)
 
 
 if __name__ == '__main__':

--- a/tests/image/test_smooth.py
+++ b/tests/image/test_smooth.py
@@ -1,25 +1,31 @@
 import unittest
+from os.path import join
 
-from image import read, write, Image
+from helpers import TestFileHelper
+from image import read, write
 
 
-class TestSmoothImage(unittest.TestCase):
-
-    img = read('./test_data/test_smooth.png')
+class TestSmoothImage(unittest.TestCase, TestFileHelper):
 
     def test_smooth(self):
         # Smooth entire image
-        smoothed = self.img.filter.blur.gaussian(kernel_size=(99, 99), sigma_x=0)
-        write('./test_data/test_smoothed.png', smoothed)
-        self.assertGreater(self.img.metrics.mse(smoothed), 0)
+        img = read(self._test_file('test_smooth.png'))
+        smoothed = img.filter.blur.gaussian(kernel_size=(99, 99), sigma_x=0)
+        with self._temp_dir() as temp_dir:
+            path = join(temp_dir, 'test_smoothed.png')
+            write(path, smoothed)
+        self.assertGreater(img.metrics.mse(smoothed), 0)
 
     def test_region(self):
         # Smooth region
-        w, h, = self.img.width, self.img.height
-        region = (int(w/2 - w/4), int(h/2 - h/4)), (int(w/2 + w/4), int(h/2 + h/4))
-        smoothed = self.img.filter.blur.gaussian(kernel_size=(99, 99), sigma_x=0, region=region)
-        write('./test_data/test_smoothed_region.png', smoothed)
-        self.assertGreater(self.img.metrics.mse(smoothed), 0)
+        img = read(self._test_file('test_smooth.png'))
+        w, h, = img.width, img.height
+        region = (int(w / 2 - w / 4), int(h / 2 - h / 4)), (int(w / 2 + w / 4), int(h / 2 + h / 4))
+        smoothed = img.filter.blur.gaussian(kernel_size=(99, 99), sigma_x=0, region=region)
+        with self._temp_dir() as temp_dir:
+            path = join(temp_dir, 'test_smoothed_region.png')
+            write(path, smoothed)
+        self.assertGreater(img.metrics.mse(smoothed), 0)
 
 
 if __name__ == '__main__':

--- a/tests/image/test_smooth.py
+++ b/tests/image/test_smooth.py
@@ -1,8 +1,7 @@
 import unittest
-from os.path import join
 
 from helpers import TestFileHelper
-from image import read, write
+from image import read
 
 
 class TestSmoothImage(unittest.TestCase, TestFileHelper):
@@ -11,10 +10,7 @@ class TestSmoothImage(unittest.TestCase, TestFileHelper):
         # Smooth entire image
         img = read(self._test_file('test_smooth.png'))
         smoothed = img.filter.blur.gaussian(kernel_size=(99, 99), sigma_x=0)
-        with self._temp_dir() as temp_dir:
-            path = join(temp_dir, 'test_smoothed.png')
-            write(path, smoothed)
-        self.assertGreater(img.metrics.mse(smoothed), 0)
+        self.assertAlmostEqual(img.metrics.mse(smoothed), 2326.74, delta=0.01)
 
     def test_region(self):
         # Smooth region
@@ -22,10 +18,7 @@ class TestSmoothImage(unittest.TestCase, TestFileHelper):
         w, h, = img.width, img.height
         region = (int(w / 2 - w / 4), int(h / 2 - h / 4)), (int(w / 2 + w / 4), int(h / 2 + h / 4))
         smoothed = img.filter.blur.gaussian(kernel_size=(99, 99), sigma_x=0, region=region)
-        with self._temp_dir() as temp_dir:
-            path = join(temp_dir, 'test_smoothed_region.png')
-            write(path, smoothed)
-        self.assertGreater(img.metrics.mse(smoothed), 0)
+        self.assertAlmostEqual(img.metrics.mse(smoothed), 1215.21, delta=0.01)
 
 
 if __name__ == '__main__':

--- a/tests/video/test_frames_extract.py
+++ b/tests/video/test_frames_extract.py
@@ -1,8 +1,5 @@
 import unittest
-from os.path import join
-from random import randint
 
-import image
 from video import Video
 
 

--- a/tests/video/test_write.py
+++ b/tests/video/test_write.py
@@ -1,14 +1,14 @@
 import unittest
 
+from numpy import array
+
 from image import Image
-from numpy import array, uint8
 from video import Video
 
 
 class TestFrames(unittest.TestCase):
 
     def test_write(self):
-
         path = r'.\test_data\video_write.mp4'
         frames = []
         codec = 'MP4V'


### PR DESCRIPTION
Переделал сохранение файлов тестах Image. Где сохранение необходимо - перенаправил во временный каталог, в остальных местах убрал.

Подправил проверки результатов. При тривиальном результате (создание одноцветной картинки) - сравниваю с вручную сгенерированным массивом. Если результат сложный, но повторяемый - с ранее записанным файлом. 

Тест на сглаживание пока не удалось сделать повторяемым. Оставил как есть.