### PR TITLE
Правки в тестах

### DIFF
--- a/tests/image/test_file_write.py
+++ b/tests/image/test_file_write.py
@@ -1,6 +1,5 @@
 import unittest
-from os import getcwd
-from os.path import exists, dirname, join, abspath, relpath
+from os.path import exists, dirname, join
 
 import cv2
 import numpy
@@ -11,24 +10,11 @@ from image import read, write
 
 class WriteImage(unittest.TestCase, TestFileHelper):
 
-    def test_absolute_path(self):
+    def test_valid_path(self):
         # Test writing a valid image
         image = read(self._test_file('test_read_image.jpg'))
         with self._temp_dir() as temp_dir:
             path = join(temp_dir, 'test_write_image.png')
-            path = abspath(path)
-            write(path, image)
-            self.assertTrue(exists(path))
-
-            new_image = read(path)
-            numpy.testing.assert_array_equal(new_image, image)
-
-    def test_relative_path(self):
-        # Test writing a valid image
-        image = read(self._test_file('test_read_image.jpg'))
-        with self._temp_dir() as temp_dir:
-            path = join(temp_dir, 'test_write_image.png')
-            path = relpath(path, getcwd())
             write(path, image)
             self.assertTrue(exists(path))
 

--- a/tests/image/test_file_write.py
+++ b/tests/image/test_file_write.py
@@ -43,6 +43,28 @@ class WriteImage(unittest.TestCase, TestFileHelper):
             with self.assertRaises(cv2.error):
                 write(path, image)
 
+    def test_cyrillic_filename(self):
+        # Test cyrillic filename
+        image = read(self._test_file('test_read_image.jpg'))
+        with self._temp_dir() as temp_dir:
+            path = os.path.join(temp_dir, 'изображение.png')
+            write(path, image)
+            self.assertTrue(os.path.exists(path))
+
+            new_image = read(path)
+            numpy.testing.assert_array_equal(new_image, image)
+
+    def test_cyrillic_path(self):
+        # Test cyrillic filename
+        image = read(self._test_file('test_read_image.jpg'))
+        with self._temp_dir() as temp_dir:
+            path = os.path.join(temp_dir, 'изображения', 'изображение.png')
+            write(path, image)
+            self.assertTrue(os.path.exists(path))
+
+            new_image = read(path)
+            numpy.testing.assert_array_equal(new_image, image)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/image/test_file_write.py
+++ b/tests/image/test_file_write.py
@@ -1,5 +1,5 @@
+import os
 import unittest
-from os.path import exists, dirname, join
 
 import cv2
 import numpy
@@ -14,9 +14,9 @@ class WriteImage(unittest.TestCase, TestFileHelper):
         # Test writing a valid image
         image = read(self._test_file('test_read_image.jpg'))
         with self._temp_dir() as temp_dir:
-            path = join(temp_dir, 'test_write_image.png')
+            path = os.path.join(temp_dir, 'test_write_image.png')
             write(path, image)
-            self.assertTrue(exists(path))
+            self.assertTrue(os.path.exists(path))
 
             new_image = read(path)
             numpy.testing.assert_array_equal(new_image, image)
@@ -25,12 +25,12 @@ class WriteImage(unittest.TestCase, TestFileHelper):
         # Test writing a valid image
         image = read(self._test_file('test_read_image.jpg'))
         with self._temp_dir() as temp_dir:
-            path = join(temp_dir, 'not_exist_dir', 'test_write_image.png')
+            path = os.path.join(temp_dir, 'not_exist_dir', 'test_write_image.png')
 
-            self.assertFalse(exists(dirname(path)))
+            self.assertFalse(os.path.exists(os.path.dirname(path)))
 
             write(path, image)
-            self.assertTrue(exists(path))
+            self.assertTrue(os.path.exists(path))
 
             new_image = read(path)
             numpy.testing.assert_array_equal(new_image, image)
@@ -39,7 +39,7 @@ class WriteImage(unittest.TestCase, TestFileHelper):
         # Test writing a valid image with improper file extension
         image = read(self._test_file('test_read_image.jpg'))
         with self._temp_dir() as temp_dir:
-            path = join(temp_dir, 'foo.xxx')
+            path = os.path.join(temp_dir, 'foo.xxx')
             with self.assertRaises(cv2.error):
                 write(path, image)
 

--- a/tests/video/test_write.py
+++ b/tests/video/test_write.py
@@ -1,31 +1,34 @@
+import os
 import unittest
 
 from numpy import array
 
-from image import Image
-from video import Video
-
 from helpers import TestFileHelper
+from image import Image
+from video import Video, Writer
 
 
 class TestFrames(unittest.TestCase, TestFileHelper):
 
     def test_write(self):
+        codec = ('a', 'v', 'c', '1')
+        frame_rate = 30
+        width = 320
+        height = 240
 
-        path = self._test_file('test_video_write.mp4')
-        frames = []
-        codec = 'AVC1'
-        framerate = 30
-        dimension = 100
+        with self._temp_dir() as temp_dir:
+            path = os.path.join(temp_dir, 'test_video_write.mp4')
 
-        for color in range(256):
-            img = Image(array([[[color, color, color] for i in range(dimension)] for j in range(dimension)]))
-            frames.append(img)
+            with Writer(path, codec, frame_rate, (width, height)) as writer:
+                for color in range(256):
+                    img = Image(array([[[color, color, color] for x in range(width)] for y in range(height)]))
+                    writer.write([img])
 
-        Video.write(frames, path, codec, framerate, (dimension, dimension))
-
-        with Video(path) as v:
-            self.assertEqual(v.length, 256)
+            with Video(path) as v:
+                self.assertEqual(256, v.length)
+                self.assertEqual(width, v.width)
+                self.assertEqual(height, v.height)
+                self.assertEqual(frame_rate, v.framerate)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Из test_absolute_path и test_relative_path сделал один test_valid_path - грамотно сделать запись во временный каталог с относительным путём не получилось. Пусть будет просто проверка записи.

TestFrames.test_write() переписал на использование video.Writer и сохранение по одному фрейму, а не всей пачкой - так чуть экономнее и при ошибках падает быстрее, на первом же фрейме.